### PR TITLE
added alphanumeric and underscore support for type name

### DIFF
--- a/super-tiny-compiler.js
+++ b/super-tiny-compiler.js
@@ -446,7 +446,7 @@ function tokenizer(input) {
     //    ^^^
     //    Name token
     //
-    var LETTERS = /[a-z]/i;
+    var LETTERS = /[a-zA-Z_0-9]/;
     if (LETTERS.test(char)) {
       var value = '';
 


### PR DESCRIPTION
Initially in the tokenizer phase the literal checking was not handling alphanumeric names.
following code should work now
console.log(compiler(' (_ad5d 2 (subtract 4 2))'));
Note that name still should not start with a number because its not a valid C identifier.
